### PR TITLE
fix: `shouldTrackEvents` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2024-08-05
+
+### Changed
+
+- Fix `shouldTrackEvents` method. Now the `defaultPayload` and `Payload` are merged before sending to the validation `shouldTrack`.
+
 ## [1.1.0] - 2024-08-02
 
 ### Added

--- a/src/Trackers/MixpanelTracker.php
+++ b/src/Trackers/MixpanelTracker.php
@@ -32,8 +32,10 @@ class MixpanelTracker implements AnalyticsTracker
             return;
         }
 
+        $payload = array_merge($this->defaultPayload, $payload);
+
         if ($this->shouldTrack($label, $payload)) {
-            $this->mixpanel->track($label, array_merge($this->defaultPayload, $payload));
+            $this->mixpanel->track($label, $payload);
         }
     }
 


### PR DESCRIPTION
Now the `defaultPayload` and `Payload` are merged before sending to the validation `shouldTrack`.